### PR TITLE
Silence E803 Error

### DIFF
--- a/autoload/zenspace.vim
+++ b/autoload/zenspace.vim
@@ -39,7 +39,7 @@ function! zenspace#update() abort
   if on
     let w:zenspace_match_id = matchadd('ZenSpace', '　')
   else
-    call matchdelete(w:zenspace_match_id)
+    silent! call matchdelete(w:zenspace_match_id)
     unlet w:zenspace_match_id
   endif
 endfunction


### PR DESCRIPTION
When zenkaku spaces are highlighted, `call clearmatches()` and `set nolist` (for example) cause below error.

with vim

```
Error detected while processing OptionSet Autocommands for "list"..function zenspace#update:
line   11:
E803: ID not found: 11
```

with neovim

```
Error detected while processing function zenspace#update:
line   11:
E803: ID not found: 9
```

I see some plugins I use is using `matchdelete` with `silent!`.
Thank you.